### PR TITLE
Fix import failure on single-frame sprites

### DIFF
--- a/addons/eska.aseprite_importer/sheet.gd
+++ b/addons/eska.aseprite_importer/sheet.gd
@@ -161,7 +161,7 @@ func _determine_format():
 func _parse_frames_dict( frames ):
 	if frames.size() == 1:
 		var old_name = frames.keys()[0]
-		var numbered_name = old_name.basename() + ' 0' + old_name.extension()
+		var numbered_name = old_name.get_basename() + ' 0.' + old_name.get_extension()
 		frames[numbered_name] = frames[old_name]
 		frames.erase( old_name )
 		


### PR DESCRIPTION
The plugin fails to import an aseprite file that has just a single frame. I tested this in Godot 3.1.

The cause seems to be either a typo, or usage of a method on `String` that has since been removed.